### PR TITLE
Add unit tests covering key functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_findpoint.py
+++ b/tests/test_findpoint.py
@@ -1,0 +1,18 @@
+import numpy as np
+from findPointByPlane import initializeFunction, findXyzt
+
+
+def test_initialize_and_find_xyzt_simple():
+    xs = np.array([1, -1, -1, 1], dtype=float)
+    ys = np.array([1, 1, -1, -1], dtype=float)
+    zs = np.zeros(4)
+    xyzt = np.array([0.0, 0.0, 1.0])
+
+    theta, phi, length, orientation = initializeFunction(xs, ys, zs, 0, xyzt)
+    assert np.isclose(length, 1.0, atol=1e-6)
+    assert np.isclose(theta, 0.0, atol=1e-6)
+    assert np.isclose(phi, 0.0, atol=1e-6)
+
+    vector, bary, norm = findXyzt(xs, ys, zs, 0, length, theta, phi, orientation)
+    reconstructed = bary + vector
+    assert np.allclose(reconstructed, xyzt, atol=1e-6)

--- a/tests/test_lever.py
+++ b/tests/test_lever.py
@@ -1,0 +1,12 @@
+import numpy as np
+from GeigerMethod.GPS_Lever_Arms import GPS_Lever_arms
+
+
+def test_gps_lever_arms_basic(capsys):
+    coords = np.array([
+        [[0,0,0], [1,0,0], [1,1,0], [0,1,0]],
+        [[0,0,0], [1,0,0], [1,1,0], [0,1,0]],
+    ])
+    GPS_Lever_arms(coords)
+    captured = capsys.readouterr()
+    assert captured.out

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,10 @@
+from printTable import printTable
+
+
+def test_print_table_simple(capsys):
+    headers = ["A", "B"]
+    data = [(1, 2), (3, 4)]
+    table = printTable(headers, data)
+    captured = capsys.readouterr()
+    assert "A" in table and "B" in table
+    assert captured.out.strip() == table.strip()

--- a/tests/test_raytracing.py
+++ b/tests/test_raytracing.py
@@ -1,0 +1,18 @@
+import os
+import numpy as np
+
+os.environ['NUMBA_DISABLE_JIT'] = '1'
+from Ray_Tracing_Iter_Locate import ray_tracing, ray_trace_locate
+
+
+def test_ray_tracing_constant_speed():
+    depth = np.linspace(0, 1000, 101)
+    cz = np.full_like(depth, 1500.0)
+    x, dz, t = ray_tracing(45.0, 0.0, 1000.0, depth, cz)
+    expected_x = 1000.0 * np.tan(np.deg2rad(45.0))
+    expected_t = np.sqrt(expected_x**2 + 1000.0**2) / 1500.0
+    assert np.isclose(x, expected_x, atol=15.0)
+    assert np.isclose(t, expected_t, atol=0.02)
+
+    alpha = ray_trace_locate(0.0, 1000.0, x, depth, cz)
+    assert np.isclose(alpha, 45.0, atol=1e-2)

--- a/tests/test_rigid_body.py
+++ b/tests/test_rigid_body.py
@@ -1,0 +1,24 @@
+import numpy as np
+from RigidBodyMovementProblem import findRotationAndDisplacement
+
+
+def test_find_rotation_and_displacement():
+    rng = np.random.default_rng(0)
+    points = rng.random((3, 5))
+
+    axis = rng.random(3)
+    axis /= np.linalg.norm(axis)
+    angle = np.pi / 3
+    K = np.array([[0, -axis[2], axis[1]],
+                  [axis[2], 0, -axis[0]],
+                  [-axis[1], axis[0], 0]])
+    R_true = np.eye(3) + np.sin(angle) * K + (1 - np.cos(angle)) * (K @ K)
+    d_true = rng.random(3)
+
+    transformed = R_true @ points + d_true[:, None]
+
+    R_est, d_est = findRotationAndDisplacement(points, transformed)
+
+    assert np.allclose(R_est @ points + d_est[:, None], transformed, atol=1e-6)
+    assert np.allclose(R_est, R_true, atol=1e-6)
+    assert np.allclose(d_est, d_true, atol=1e-6)

--- a/tests/test_svp.py
+++ b/tests/test_svp.py
@@ -1,0 +1,31 @@
+import numpy as np
+from SVP_Calculations import (
+    depth_to_pressure_Leroy,
+    depth_to_pressure,
+    DelGrosso_SV,
+    UNESCO_SV,
+    NPL_ESV,
+    Mackenzie_ESV,
+    Coppens_ESV,
+)
+
+
+def test_depth_to_pressure_functions():
+    p1 = depth_to_pressure_Leroy(1000, 30)
+    p2 = depth_to_pressure(1000, 30)
+    assert np.isclose(p1, 100.6729, atol=1e-3)
+    assert np.isclose(p2, 100.9554, atol=1e-3)
+
+
+def test_sound_speed_models():
+    S, T, P, Z, lat = 35.0, 10.0, 100.0, 1000.0, 30.0
+    dg = DelGrosso_SV(S, T, P)
+    un = UNESCO_SV(S, T, P)
+    npl = NPL_ESV(S, T, Z, lat)
+    mac = Mackenzie_ESV(S, T, Z)
+    cop = Coppens_ESV(S, T, Z)
+    assert np.isclose(dg, 1506.138, atol=0.01)
+    assert np.isclose(un, 1506.348, atol=0.01)
+    assert np.isclose(npl, 1506.170, atol=0.01)
+    assert np.isclose(mac, 1506.264, atol=0.01)
+    assert np.isclose(cop, 1506.366, atol=0.01)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import numpy as np
+from rodriguesRotationMatrix import rotationMatrix
+from projectToPlane import projectToPlane
+from fitPlane import fitPlane
+
+
+def test_rotation_matrix_z_axis():
+    vec = np.array([1.0, 0.0, 0.0])
+    R = rotationMatrix(np.pi/2, np.array([0.0, 0.0, 1.0]))
+    rotated = R @ vec
+    assert np.allclose(rotated, np.array([0.0, 1.0, 0.0]), atol=1e-6)
+
+
+def test_project_to_plane_xy():
+    vect = np.array([1.0, 2.0, 3.0])
+    norm = np.array([0.0, 0.0, 1.0])
+    projected = projectToPlane(vect, norm)
+    assert np.allclose(projected, np.array([1.0, 2.0, 0.0]), atol=1e-6)
+
+
+def test_fit_plane_known_plane():
+    xs = np.array([0.0, 1.0, -1.0, 2.0, -2.0])
+    ys = np.array([0.0, -1.0, 1.0, 0.5, -0.5])
+    zs = 2 * xs + 3 * ys + 5
+    norm = fitPlane(xs, ys, zs)
+    expected = np.array([2.0, 3.0, -1.0])
+    norm /= np.linalg.norm(norm)
+    expected /= np.linalg.norm(expected)
+    assert np.allclose(np.abs(np.dot(norm, expected)), 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary
- add pytest configuration to put repo on path
- test rotation matrices, plane fitting, and vector projection
- test findPointByPlane workflow
- verify rigid-body transformations
- check sound velocity calculations
- test ray tracing behaviour
- verify table printing utility and lever arm calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477e01fba8832fa2ffc23578970e58