### PR TITLE
Add pre-commit and CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test,dev]
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: mixed-line-ending
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ test = [
     "pytest",
     "pytest-cov",
 ]
+dev = [
+    "pre-commit",
+]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- configure pre-commit with black, ruff, and common hooks
- add GitHub Actions workflow running pre-commit and pytest
- expose `pre-commit` via dev extras in `pyproject.toml`

## Testing
- `pre-commit run --files .pre-commit-config.yaml pyproject.toml .github/workflows/ci.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484952d2a8832f9e06b40b7dd2e39d