### PR TITLE
Align ruff configuration with black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,16 @@ build-backend = "hatchling.build"
 packages = ["GeigerMethod"]
 include = ["*.py"]
 
+[tool.black]
+line-length = 88
+
 [tool.ruff]
-line-length = 100
+line-length = 88
 
 [tool.ruff.lint]
 select = ["E", "F", "B"]
 
 [tool.ruff.format]
-quote-style = "single"
-indent-style = "tab"
+quote-style = "double"
+indent-style = "space"
 docstring-code-format = true


### PR DESCRIPTION
## Summary
- configure Black and Ruff with matching line lengths
- use the same formatting style in Ruff as Black

## Testing
- `pre-commit run --files pyproject.toml`
- `ruff check pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_6848786a3b74832fa52441122c077903