### PR TITLE
Add initial docstrings to Numba functions

### DIFF
--- a/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Trajectory.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Trajectory.py
@@ -9,7 +9,24 @@ from Numba_time_bias import calculateTimesRayTracing_Bias_Real
 def bermuda_trajectory(
     time_noise, position_noise, dz_array, angle_array, esv_matrix, DOG_num=3
 ):
-    """Calculate trajectory and synthetic arrival times for Bermuda dataset"""
+    """Generate synthetic Bermuda trajectory and travel times.
+
+    Parameters
+    ----------
+    time_noise : float
+        Standard deviation of timing noise added to the data.
+    position_noise : float
+        Standard deviation of position noise in metres.
+    dz_array, angle_array, esv_matrix : ndarray
+        Effective sound velocity lookup tables.
+    DOG_num : int, optional
+        DOG data set to load (1–4).
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(CDOG_data, CDOG, GPS_Coordinates, GPS_data, transponder_coordinates)``.
+    """
     CDOG_base = np.array([1976671.618715, -5069622.53769779, 3306330.69611698])
     CDOG_augment = np.array([974.12667502, -80.98121315, -805.07870249])
     CDOG = CDOG_base + CDOG_augment

--- a/GeigerMethod/Synthetic/Numba_Functions/Compare_ESV_Table.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/Compare_ESV_Table.py
@@ -6,6 +6,19 @@ from Numba_Geiger import generateRealistic, findTransponder
 
 
 def compare_tables(esv_table1, esv_table2):
+    """Compare two ESV lookup tables using a synthetic scenario.
+
+    Parameters
+    ----------
+    esv_table1, esv_table2 : dict
+        ``.mat`` structures with ``distance``, ``angle`` and ``matrice`` arrays.
+
+    Returns
+    -------
+    None
+        Statistics are printed to ``stdout``.
+    """
+
     dz_array_gen = esv_table1["distance"].flatten()
     angle_array_gen = esv_table1["angle"].flatten()
     esv_matrix_gen = esv_table1["matrice"]

--- a/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
@@ -6,21 +6,27 @@ from Numba_time_bias import find_esv
 def calculateTimesRayTracing_split(
     guess, transponder_coordinates, esv_biases, dz_array, angle_array, esv_matrix
 ):
-    """
-    Ray Tracing calculation of times using ESV
-        Capable of handling an array of ESV biases split by time
-    :param guess:
-        The guess for the position of the source.
-    :param transponder_coordinates:
-        The transponder coordinates to calculate the times for.
-    :param esv_biases:
-        The array of ESV biases to be applied to the transponder coordinates.
-    :param dz_array:
-        The array of depth differences to be used for the ESV calculation.
-    :param angle_array:
-        The array of angles to be used for the ESV calculation.
-    :param esv_matrix:
-        The ESV matrix to be used for the ESV calculation.
+    """Ray trace times with separate ESV biases for consecutive blocks.
+
+    Parameters
+    ----------
+    guess : array-like of float, shape (3,)
+        Current estimate of the source location.
+    transponder_coordinates : ndarray
+        ``(N, 3)`` array of transponder positions.
+    esv_biases : ndarray
+        Sequence of ESV biases applied in order along the track.
+    dz_array : ndarray
+        Depth grid used for the ESV table.
+    angle_array : ndarray
+        Angle grid used for the ESV table in degrees.
+    esv_matrix : ndarray
+        Effective sound velocity table.
+
+    Returns
+    -------
+    tuple of ndarray
+        ``(times, esv)`` travel times and effective sound speeds.
     """
     times = np.zeros(len(transponder_coordinates))
     esv = np.zeros(len(transponder_coordinates))

--- a/GeigerMethod/Synthetic/Numba_Functions/Error_Ellipse.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/Error_Ellipse.py
@@ -65,6 +65,23 @@ def _plot_error_ellipse(
 
 
 def error_ellipse(num_points, time_noise, position_noise):
+    """Plot error ellipses from Monte Carlo samples.
+
+    Parameters
+    ----------
+    num_points : int
+        Number of Monte Carlo iterations to run.
+    time_noise : float
+        Standard deviation of timing noise.
+    position_noise : float
+        Standard deviation of position noise in metres.
+
+    Returns
+    -------
+    None
+        Displays plots of the estimated CDOG positions and lever errors.
+    """
+
     # Real Lever
     real_lever = np.array([-12.48862757, 0.22622633, -15.89601934])
 

--- a/GeigerMethod/Synthetic/Numba_Functions/Gaussian_search.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/Gaussian_search.py
@@ -15,9 +15,31 @@ def gaussian_search_individual(
     sigma_gps_grid=None,
     downsample=50,
 ):
-    """
-    Samples lever and GPS‐grid parameters in Gaussian fashion and computes
-    the RMSE Gaussian for a single DOG (index 0–2).
+    """Sample lever and grid parameters for a single DOG.
+
+    Parameters
+    ----------
+    dog_idx : int
+        Index of the DOG (0–2).
+    num_points : int
+        Number of samples to generate.
+    output_file : str, optional
+        Destination file for the RMSE results.
+    initial_lever_base : ndarray, optional
+        Base estimate of the lever arm.
+    initial_gps_grid : ndarray, optional
+        Estimated GPS grid for DOG1.
+    sigma_lever : ndarray, optional
+        Standard deviation of lever perturbations.
+    sigma_gps_grid : ndarray, optional
+        Standard deviation of GPS grid perturbations.
+    downsample : int, optional
+        Downsample factor for the raw data.
+
+    Returns
+    -------
+    None
+        Results are written to ``output_file``.
     """
     if initial_lever_base is None:
         initial_lever_base = np.array([-12.4659, 9.6021, -13.2993])
@@ -146,24 +168,29 @@ def gaussian_search(
     sigma_gps_grid=None,
     downsample=50,
 ):
-    """
-    Function to sample the GPS grid and GPS to transducer in a Gaussian distribution.
-        Calculates the RMSE of the joint CDOGs and saves each sample and RMSE to a file.
+    """Perform a Gaussian search over lever and grid parameters.
 
     Parameters
     ----------
     num_points : int
-        Number of points to sample in the Gaussian distribution.
-    output_file : str
-        Path to the output file.
-    CDOG_guess_augment : np.ndarray
-        Augmented guess for CDOG coordinates.
-    initial_lever_base : np.ndarray
-        Base guess for the initial lever arm.
-    initial_gps_grid : np.ndarray
-        Initial guess for the GPS grid coordinates.
-    downsample : int
-        Downsample factor for the data.
+        Number of samples to generate.
+    output_file : str, optional
+        File where the combined RMSE values are stored.
+    initial_lever_base : ndarray, optional
+        Base estimate of the lever arm.
+    initial_gps_grid : ndarray, optional
+        Estimated GPS grid for DOG1.
+    sigma_lever : ndarray, optional
+        Standard deviation of lever perturbations.
+    sigma_gps_grid : ndarray, optional
+        Standard deviation of GPS grid perturbations.
+    downsample : int, optional
+        Downsample factor for the raw data.
+
+    Returns
+    -------
+    None
+        The RMSE values are written to ``output_file``.
     """
     if initial_lever_base is None:
         initial_lever_base = np.array([-12.4659, 9.6021, -13.2993])

--- a/GeigerMethod/Synthetic/Numba_Functions/Geometric_Dilution.py
+++ b/GeigerMethod/Synthetic/Numba_Functions/Geometric_Dilution.py
@@ -7,6 +7,20 @@ from Modular_Synthetic import modular_synthetic
 
 
 def geometric_dilution(interval):
+    """Plot the geometric dilution of precision for a given interval.
+
+    Parameters
+    ----------
+    interval : int
+        Step between successive transponder points used in the GDOP
+        calculation.
+
+    Returns
+    -------
+    None
+        A figure showing GDOP versus time is displayed.
+    """
+
     table_str = "global_table_esv_realistic_perturbed"
 
     (


### PR DESCRIPTION
## Summary
- document functions within the Numba_Functions folder
- update docstrings for geometry and synthetic utilities

## Testing
- `pre-commit run --files GeigerMethod/Synthetic/Numba_Functions/Geometric_Dilution.py GeigerMethod/Synthetic/Numba_Functions/Compare_ESV_Table.py GeigerMethod/Synthetic/Numba_Functions/Bermuda_Trajectory.py GeigerMethod/Synthetic/Numba_Functions/Error_Ellipse.py GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py GeigerMethod/Synthetic/Numba_Functions/Gaussian_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848893b8700832fac7613e9a007d55a