### PR TITLE
Fix NUMBA env var placement for lint

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
+import os
 import sys
 from pathlib import Path
+
+os.environ["NUMBA_DISABLE_JIT"] = "1"
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"

--- a/tests/test_raytracing.py
+++ b/tests/test_raytracing.py
@@ -1,8 +1,5 @@
-import os
 import numpy as np
 from acoustics.ray_tracing import ray_tracing, ray_trace_locate
-
-os.environ["NUMBA_DISABLE_JIT"] = "1"
 
 
 def test_ray_tracing_constant_speed():


### PR DESCRIPTION
## Summary
- move `NUMBA_DISABLE_JIT` environment variable setup to `conftest.py`
- clean up `tests/test_raytracing.py`

## Testing
- `ruff check tests/conftest.py tests/test_raytracing.py`
- `black --check tests/conftest.py tests/test_raytracing.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857540e4cf4832f996da11ac0bfc18e