### PR TITLE
Fix local imports and circular dependency

### DIFF
--- a/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Data.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Data.py
@@ -1,15 +1,15 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_Geiger import (
+from .Numba_Geiger import (
     findTransponder,
 )
-from Numba_xAline_Geiger import initial_geiger, transition_geiger, final_geiger
-from Initialize_Bermuda_Data import initialize_bermuda
+from .Numba_xAline_Geiger import initial_geiger, transition_geiger, final_geiger
+from .Initialize_Bermuda_Data import initialize_bermuda
 
 import matplotlib.pyplot as plt
 
-from data import gps_data_path
+from ...data import gps_data_path
 
 esv_table = sio.loadmat(gps_data_path("global_table_esv.mat"))
 

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Data_time_bias.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Data_time_bias.py
@@ -1,19 +1,19 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_Geiger import findTransponder
-from Numba_xAline_bias import (
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_bias import (
     initial_bias_geiger,
     transition_bias_geiger,
     final_bias_geiger,
 )
-from Numba_time_bias import calculateTimesRayTracing_Bias_Real
-from Numba_xAline import two_pointer_index
-from Plot_Modular import time_series_plot, range_residual
+from .Numba_time_bias import calculateTimesRayTracing_Bias_Real
+from .Numba_xAline import two_pointer_index
+from .Plot_Modular import time_series_plot, range_residual
 
 
 # esv_table = sio.loadmat('../../../GPSData/global_table_esv.mat')
-from data import gps_data_path
+from ...data import gps_data_path
 
 esv_table = sio.loadmat(gps_data_path("global_table_esv_normal.mat"))
 

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Trajectory.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Bermuda_Trajectory.py
@@ -2,9 +2,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.io as sio
 from pymap3d import ecef2geodetic
-from Numba_Geiger import findTransponder
-from Numba_time_bias import calculateTimesRayTracing_Bias_Real
-from data import gps_data_path
+from .Numba_Geiger import findTransponder
+from .Numba_time_bias import calculateTimesRayTracing_Bias_Real
+from ...data import gps_data_path
 
 
 def bermuda_trajectory(

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Compare_ESV_Table.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Compare_ESV_Table.py
@@ -1,9 +1,9 @@
 import numpy as np
 import scipy.io as sio
 import random
-from Numba_time_bias import numba_bias_geiger, find_esv
-from Numba_Geiger import generateRealistic, findTransponder
-from data import gps_data_path
+from .Numba_time_bias import numba_bias_geiger, find_esv
+from .Numba_Geiger import generateRealistic, findTransponder
+from ...data import gps_data_path
 
 
 def compare_tables(esv_table1, esv_table2):

--- a/src/GeigerMethod/Synthetic/Numba_Functions/ECEF_Geodetic.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/ECEF_Geodetic.py
@@ -7,10 +7,9 @@ Function to convert from ECEF coordinates to Geodetic coordinates
 import numpy as np
 from numba import njit
 from pymap3d import ecef2geodetic
-from Numba_Geiger import findTransponder
 import scipy.io as sio
 import timeit
-from data import gps_data_path
+from ...data import gps_data_path
 
 
 @njit(cache=True)
@@ -55,6 +54,7 @@ def ECEF_Geodetic(coords):
 
 
 if __name__ == "__main__":
+    from .Numba_Geiger import findTransponder
 
     def load_and_process_data(path):
         """Load unit data and slice to the GNSS window.

--- a/src/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
@@ -1,5 +1,5 @@
 import numpy as np
-from Numba_time_bias import find_esv
+from .Numba_time_bias import find_esv
 
 
 # @njit

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Gaussian_search.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Gaussian_search.py
@@ -1,9 +1,9 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_xAline_bias import final_bias_geiger
-from Numba_Geiger import findTransponder
-from data import gps_data_path
+from .Numba_xAline_bias import final_bias_geiger
+from .Numba_Geiger import findTransponder
+from ...data import gps_data_path
 
 
 def gaussian_search_individual(

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Generate_Unaligned_Realistic.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Generate_Unaligned_Realistic.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.io as sio
 import matplotlib.pyplot as plt
-from Numba_Geiger import generateRealistic
+from .Numba_Geiger import generateRealistic
 
 
 def find_esv_generate(beta, dz, dz_array, angle_array, esv_matrix):
@@ -220,7 +220,7 @@ if __name__ == "__main__":
     )  # Numpy page describes how unwrap works
 
     # Save the CDOG to a matlabfile
-    from data import gps_data_path
+    from ...data import gps_data_path
 
     sio.savemat(
         gps_data_path("Realistic_CDOG_noise_subint_new.mat"),

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Geometric_Dilution.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Geometric_Dilution.py
@@ -2,9 +2,9 @@ import numpy as np
 import scipy.io as sio
 import matplotlib.pyplot as plt
 
-from Numba_time_bias import compute_Jacobian_biased, calculateTimesRayTracing_Bias
-from Modular_Synthetic import modular_synthetic
-from data import gps_data_path
+from .Numba_time_bias import compute_Jacobian_biased, calculateTimesRayTracing_Bias
+from .Modular_Synthetic import modular_synthetic
+from ...data import gps_data_path
 
 
 def geometric_dilution(interval):

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Grid_Search.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Grid_Search.py
@@ -1,11 +1,11 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_xAline_bias import final_bias_geiger
-from Numba_Geiger import findTransponder
-from Numba_xAline_Annealing_bias import simulated_annealing_bias
-from Initialize_Bermuda_Data import initialize_bermuda
-from data import gps_data_path
+from .Numba_xAline_bias import final_bias_geiger
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_Annealing_bias import simulated_annealing_bias
+from .Initialize_Bermuda_Data import initialize_bermuda
+from ...data import gps_data_path
 
 
 def grid_search_annealing(xl, xh, yl, yh, zl, zh, iter):

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Grid_Search_offset_Z.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Grid_Search_offset_Z.py
@@ -2,10 +2,10 @@ import numpy as np
 import scipy.io as sio
 import itertools
 
-from Numba_xAline_bias import final_bias_geiger, initial_bias_geiger
-from Numba_Geiger import findTransponder
-from Real_Annealing import simulated_annealing_real
-from data import gps_data_path
+from .Numba_xAline_bias import final_bias_geiger, initial_bias_geiger
+from .Numba_Geiger import findTransponder
+from .Real_Annealing import simulated_annealing_real
+from ...data import gps_data_path
 
 """Plot all of the Seafloor guesses from the grid search and find the correlation
 

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Initialize_Bermuda_Data.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Initialize_Bermuda_Data.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.io as sio
 from pymap3d import geodetic2ecef
-from data import gps_data_path
+from ...data import gps_data_path
 
 """Enable this for paper plots"""
 # plt.rcParams.update({

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Lever_z_locate.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Lever_z_locate.py
@@ -1,14 +1,14 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_Geiger import findTransponder
-from Numba_xAline_bias import (
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_bias import (
     initial_bias_geiger,
     transition_bias_geiger,
     final_bias_geiger,
 )
-from Bermuda_Trajectory import bermuda_trajectory
-from data import gps_data_path
+from .Bermuda_Trajectory import bermuda_trajectory
+from ...data import gps_data_path
 
 esv_table_generate = sio.loadmat(gps_data_path("global_table_esv.mat"))
 dz_array_generate = esv_table_generate["distance"].flatten()

--- a/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
@@ -1,11 +1,11 @@
 import numpy as np
 import scipy.io as sio
 
-from Numba_time_bias import calculateTimesRayTracing_Bias_Real
-from Numba_xAline import two_pointer_index
-from Numba_Geiger import findTransponder
-from ESV_bias_split import calculateTimesRayTracing_split
-from data import gps_data_path
+from .Numba_time_bias import calculateTimesRayTracing_Bias_Real
+from .Numba_xAline import two_pointer_index
+from .Numba_Geiger import findTransponder
+from .ESV_bias_split import calculateTimesRayTracing_split
+from ...data import gps_data_path
 
 
 # @njit

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Modular_Synthetic.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Modular_Synthetic.py
@@ -1,17 +1,17 @@
 import numpy as np
 import scipy.io as sio
 
-from Generate_Unaligned_Realistic import generateUnalignedRealistic
-from Bermuda_Trajectory import bermuda_trajectory
-from Numba_Geiger import findTransponder
-from Numba_xAline_bias import (
+from .Generate_Unaligned_Realistic import generateUnalignedRealistic
+from .Bermuda_Trajectory import bermuda_trajectory
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_bias import (
     initial_bias_geiger,
     transition_bias_geiger,
     final_bias_geiger,
 )
-from Numba_xAline_Annealing_bias import simulated_annealing_bias
-from Plot_Modular import time_series_plot
-from data import gps_data_path
+from .Numba_xAline_Annealing_bias import simulated_annealing_bias
+from .Plot_Modular import time_series_plot
+from ...data import gps_data_path
 
 """
 File to allow for easy changing of parameters when running synthetic

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_Geiger.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_Geiger.py
@@ -2,9 +2,9 @@ import random
 import numpy as np
 import scipy.io as sio
 from numba import njit
-from Numba_RigidBodyMovementProblem import findRotationAndDisplacement
-from ECEF_Geodetic import ECEF_Geodetic
-from data import gps_data_path
+from .Numba_RigidBodyMovementProblem import findRotationAndDisplacement
+from .ECEF_Geodetic import ECEF_Geodetic
+from ...data import gps_data_path
 import timeit
 
 

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_time_bias.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_time_bias.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import njit
-from ECEF_Geodetic import ECEF_Geodetic
+from .ECEF_Geodetic import ECEF_Geodetic
 
 
 @njit

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline.py
@@ -220,8 +220,8 @@ def find_int_offset(
 
 
 if __name__ == "__main__":
-    from Numba_Geiger import calculateTimesRayTracing, findTransponder
-    from Generate_Unaligned_Realistic import generateUnalignedRealistic
+    from .Numba_Geiger import calculateTimesRayTracing, findTransponder
+    from .Generate_Unaligned_Realistic import generateUnalignedRealistic
 
     n = 10000
     true_offset = np.random.rand() * 10000

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Annealing.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Annealing.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from Numba_xAline import two_pointer_index, find_subint_offset
-from Numba_xAline_Geiger import (
+from .Numba_xAline import two_pointer_index, find_subint_offset
+from .Numba_xAline_Geiger import (
     initial_geiger,
     transition_geiger,
     final_geiger,
@@ -9,7 +9,7 @@ from Numba_xAline_Geiger import (
     findTransponder,
     calculateTimesRayTracingReal,
 )
-from Generate_Unaligned_Realistic import generateUnalignedRealistic
+from .Generate_Unaligned_Realistic import generateUnalignedRealistic
 
 """
 Maybe try to implement the more complicated schematic

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Annealing_bias.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Annealing_bias.py
@@ -1,18 +1,18 @@
 import numpy as np
 import scipy.io as sio
 
-from Bermuda_Trajectory import bermuda_trajectory
-from Numba_xAline import two_pointer_index
-from Numba_time_bias import calculateTimesRayTracing_Bias
-from Numba_Geiger import findTransponder
-from Numba_xAline_bias import (
+from .Bermuda_Trajectory import bermuda_trajectory
+from .Numba_xAline import two_pointer_index
+from .Numba_time_bias import calculateTimesRayTracing_Bias
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_bias import (
     initial_bias_geiger,
     transition_bias_geiger,
     final_bias_geiger,
     calculateTimesRayTracing_Bias_Real,
 )
-from Plot_Modular import time_series_plot
-from data import gps_data_path
+from .Plot_Modular import time_series_plot
+from ...data import gps_data_path
 
 """
 Incorporate simulated annealing to find

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Geiger.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_Geiger.py
@@ -1,15 +1,15 @@
 import numpy as np
 from numba import njit
-from Numba_Geiger import (
+from .Numba_Geiger import (
     computeJacobianRayTracing,
     findTransponder,
     calculateTimesRayTracing,
     calculateTimesRayTracingReal,
 )
-from Numba_xAline import two_pointer_index, find_subint_offset, find_int_offset
-from Generate_Unaligned_Realistic import generateUnalignedRealistic
+from .Numba_xAline import two_pointer_index, find_subint_offset, find_int_offset
+from .Generate_Unaligned_Realistic import generateUnalignedRealistic
 import scipy.io as sio
-from data import gps_data_path
+from ...data import gps_data_path
 
 
 def initial_geiger(

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_bias.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Numba_xAline_bias.py
@@ -1,17 +1,17 @@
 import numpy as np
 import scipy.io as sio
 
-from Bermuda_Trajectory import bermuda_trajectory
-from Numba_xAline import two_pointer_index, find_int_offset
-from Numba_time_bias import (
+from .Bermuda_Trajectory import bermuda_trajectory
+from .Numba_xAline import two_pointer_index, find_int_offset
+from .Numba_time_bias import (
     calculateTimesRayTracing_Bias,
     calculateTimesRayTracing_Bias_Real,
     compute_Jacobian_biased,
 )
-from Numba_Geiger import findTransponder
+from .Numba_Geiger import findTransponder
 from numba import njit
-from Plot_Modular import time_series_plot
-from data import gps_data_path
+from .Plot_Modular import time_series_plot
+from ...data import gps_data_path
 
 
 def initial_bias_geiger(

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Plot_Modular.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Plot_Modular.py
@@ -1,8 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import norm
-from ECEF_Geodetic import ECEF_Geodetic
-from data import gps_data_path
+from .ECEF_Geodetic import ECEF_Geodetic
+from ...data import gps_data_path
 
 """Enable this for paper plots"""
 plt.rcParams.update(

--- a/src/GeigerMethod/Synthetic/Numba_Functions/Real_Annealing.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/Real_Annealing.py
@@ -2,10 +2,10 @@ import numpy as np
 import scipy.io as sio
 from numba import njit
 
-from Numba_Geiger import findTransponder
-from Numba_xAline_bias import final_bias_geiger, initial_bias_geiger
-from Bermuda_Trajectory import bermuda_trajectory
-from data import gps_data_path
+from .Numba_Geiger import findTransponder
+from .Numba_xAline_bias import final_bias_geiger, initial_bias_geiger
+from .Bermuda_Trajectory import bermuda_trajectory
+from ...data import gps_data_path
 
 
 @njit


### PR DESCRIPTION
## Summary
- avoid circular import by lazily importing `findTransponder` in `ECEF_Geodetic`
- use relative imports within `Numba_Functions` modules
- update call sites accordingly

## Testing
- `pip install -q numpy matplotlib scipy pandas numba pymap3d`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575f7ce348832fb528b696a541b13f