### PR TITLE
Fix sys.path resolution in MCMC sampler

### DIFF
--- a/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
@@ -7,15 +7,20 @@ from pathlib import Path
 
 # Allow running this module directly without installing the package.
 if __package__ is None or __package__ == "":
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    # Ensure the project's ``src`` directory is available for absolute imports
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 import numpy as np
 import scipy.io as sio
 
-from GeigerMethod.Synthetic.Numba_Functions.Numba_time_bias import calculateTimesRayTracing_Bias_Real
+from GeigerMethod.Synthetic.Numba_Functions.Numba_time_bias import (
+    calculateTimesRayTracing_Bias_Real,
+)
 from GeigerMethod.Synthetic.Numba_Functions.Numba_xAline import two_pointer_index
 from GeigerMethod.Synthetic.Numba_Functions.Numba_Geiger import findTransponder
-from GeigerMethod.Synthetic.Numba_Functions.ESV_bias_split import calculateTimesRayTracing_split
+from GeigerMethod.Synthetic.Numba_Functions.ESV_bias_split import (
+    calculateTimesRayTracing_split,
+)
 from GeigerMethod.data import gps_data_path
 
 


### PR DESCRIPTION
## Summary
- fix parent path resolution for running module directly
- add comment clarifying why sys.path is updated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68576f58689c832fad1178ca4212860b