### PR TITLE
Add geometry and ray tracing tests

### DIFF
--- a/tests/test_findpoint.py
+++ b/tests/test_findpoint.py
@@ -1,5 +1,11 @@
 import numpy as np
-from geometry.find_point_by_plane import initializeFunction, findXyzt
+from geometry.find_point_by_plane import (
+    initializeFunction,
+    findXyzt,
+    findTheta,
+    findPhi,
+    findLength,
+)
 
 
 def test_initialize_and_find_xyzt_simple():
@@ -16,3 +22,22 @@ def test_initialize_and_find_xyzt_simple():
     vector, bary, norm = findXyzt(xs, ys, zs, 0, length, theta, phi, orientation)
     reconstructed = bary + vector
     assert np.allclose(reconstructed, xyzt, atol=1e-6)
+
+
+def test_findpoint_helpers():
+    bary = np.array([0.0, 0.0, 0.0])
+    norm = np.array([0.0, 0.0, 1.0])
+
+    theta = findTheta(bary, np.array([0.0, 0.0, 1.0]), norm)
+    assert np.isclose(theta, 0.0, atol=1e-6)
+
+    theta = findTheta(bary, np.array([1.0, 0.0, 0.0]), norm)
+    assert np.isclose(theta, np.pi / 2, atol=1e-6)
+
+    phi1 = findPhi(bary, np.array([1.0, 1.0, 0.0]), np.array([1.0, 0.0, 0.0]), norm)
+    phi2 = findPhi(bary, np.array([1.0, -1.0, 0.0]), np.array([1.0, 0.0, 0.0]), norm)
+    assert np.isclose(phi1, np.pi / 4, atol=1e-6)
+    assert np.isclose(phi2, -np.pi / 4, atol=1e-6)
+
+    length = findLength(bary, np.array([1.0, 2.0, 2.0]))
+    assert np.isclose(length, 3.0, atol=1e-6)

--- a/tests/test_raytracing.py
+++ b/tests/test_raytracing.py
@@ -13,3 +13,12 @@ def test_ray_tracing_constant_speed():
 
     alpha = ray_trace_locate(0.0, 1000.0, x, depth, cz)
     assert np.isclose(alpha, 45.0, atol=1e-2)
+
+
+def test_ray_tracing_total_internal_reflection():
+    depth = np.array([0.0, 50.0, 100.0])
+    cz = np.array([1500.0, 2000.0, 2000.0])
+    x, dz, t = ray_tracing(0.0, 0.0, 100.0, depth, cz)
+    assert np.isnan(x)
+    assert np.isnan(t)
+    assert dz == 100.0


### PR DESCRIPTION
## Summary
- increase coverage for geometry.find_point_by_plane helper functions
- test `ray_tracing` behaviour for total internal reflection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587353d598832f8fb0371687690f6f