### PR TITLE
Add GeigerMethod submodule documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Convenience helpers for visualising results.
 
 The `examples` and `GeigerMethod` directories contain scripts and
 notebooks used during development. They illustrate typical workflows for
-processing GPS data and analysing transducer positions.
+processing GPS data and analysing transducer positions. See the
+[GeigerMethod README](src/GeigerMethod/README.md) for an overview of
+these helper modules.
 
 ## Usage
 

--- a/src/GeigerMethod/README.md
+++ b/src/GeigerMethod/README.md
@@ -1,0 +1,23 @@
+# GeigerMethod package
+
+This directory holds research code implementing variations of the
+**Geiger method** for underwater acoustic positioning.  Most scripts were
+written for experiments around Bermuda and for testing algorithms on
+simulated data.
+
+The main components are:
+
+- **Field data scripts** – `geigerMethod_Bermuda.py`,
+  `Bermuda_Data_Parse.py`, `Bermuda_Data_Analyze.py`,
+  `simulatedAnnealing_Bermuda.py` and related helpers for analysing the
+  Bermuda deployment.
+- **`GPS_Lever_Arms.py`** – compute lever arms between GPS receivers
+  using rigid‑body plane fitting.
+- **`Synthetic/`** – tools for generating artificial transponder and GPS
+  trajectories.  Includes optimisation routines (Bayesian search,
+  simulated annealing) and plotting utilities.
+- **`Synthetic/Numba_Functions/`** – numba‑accelerated kernels for
+  ray tracing, rigid‑body estimation and the Geiger solver.
+
+The scripts are not packaged as part of the library but serve as
+examples and utilities when developing new localisation methods.


### PR DESCRIPTION
## Summary
- document the purpose of the GeigerMethod scripts
- link the GeigerMethod README from the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed90e2f90832f89692e99b6b88994