### PR TITLE
Make compute_log_likelihood numba compatible

### DIFF
--- a/src/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/ESV_bias_split.py
@@ -1,9 +1,10 @@
 import numpy as np
+from numba import njit
 from GeigerMethod.Synthetic.Numba_Functions.Numba_time_bias import find_esv
 from GeigerMethod.Synthetic.Numba_Functions.ECEF_Geodetic import ECEF_Geodetic
 
 
-# @njit
+@njit
 def calculateTimesRayTracing_split(
     guess, transponder_coordinates, esv_biases, dz_array, angle_array, esv_matrix
 ):
@@ -29,37 +30,37 @@ def calculateTimesRayTracing_split(
     tuple of ndarray
         ``(times, esv)`` travel times and effective sound speeds.
     """
-    N = len(transponder_coordinates)
-    B = len(esv_biases)
+    N = transponder_coordinates.shape[0]
+    B = esv_biases.shape[0]
 
     # Get depth of receiver guess
     guess = guess[np.newaxis, :]
     lat, lon, depth = ECEF_Geodetic(guess)
 
-    # 1) Split coords into B blocks (some blocks may be 1 sample larger)
-    blocks = np.array_split(transponder_coordinates, B, axis=0)
-    # 2) Prepare output arrays
+    # Output arrays
     times = np.zeros(N)
     esv = np.zeros(N)
 
-    # 3) Compute cumulative indices so we know where each block lives in the full vector
-    lengths = [blk.shape[0] for blk in blocks]
-    cumidx = np.concatenate(([0], np.cumsum(lengths)))
+    # Determine block sizes (equivalent to np.array_split)
+    base = N // B
+    remainder = N % B
+    start = 0
 
-    # 4) Loop each block/apply its bias
     for n in range(B):
-        blk = blocks[n]
-        left, right = cumidx[n], cumidx[n + 1]
+        size = base + 1 if n < remainder else base
+        end = start + size
 
+        blk = transponder_coordinates[start:end]
         depth_arr = ECEF_Geodetic(blk)[2]
 
-        # vertical & absolute distances on this block
         dz = depth_arr - depth
         abs_dist = np.sqrt(np.sum((blk - guess) ** 2, axis=1))
         beta = np.arcsin(dz / abs_dist) * 180 / np.pi
 
-        # lookup & bias
         block_esv = find_esv(beta, dz, dz_array, angle_array, esv_matrix)
-        esv[left:right] = block_esv + esv_biases[n]
-        times[left:right] = abs_dist / esv[left:right]
+        esv[start:end] = block_esv + esv_biases[n]
+        times[start:end] = abs_dist / esv[start:end]
+
+        start = end
+
     return times, esv

--- a/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
+++ b/src/GeigerMethod/Synthetic/Numba_Functions/MCMC_sampler.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 import scipy.io as sio
+from numba import njit
+from numba.typed import List
 
 from GeigerMethod.Synthetic.Numba_Functions.Numba_time_bias import (
     calculateTimesRayTracing_Bias_Real,
@@ -14,7 +16,7 @@ from GeigerMethod.Synthetic.Numba_Functions.ESV_bias_split import (
 from data import gps_data_path, gps_output_path
 
 
-# @njit
+@njit
 def compute_log_likelihood(
     lever_guess,
     gps1_grid_guess,
@@ -42,50 +44,45 @@ def compute_log_likelihood(
     for j in range(3):
         inv_guess = CDOG_guess + CDOG_augments[j]
         CDOG_data = CDOG_all_data[j]
-        try:
-            # Calculate the times either with the split ESV bias or the regular ESV bias
-            if split_esv:
-                times_guess, esv = calculateTimesRayTracing_split(
-                    inv_guess,
-                    trans_coords,
-                    esv_bias[j],
-                    dz_array,
-                    angle_array,
-                    esv_matrix,
-                )
-            else:
-                times_guess, esv = calculateTimesRayTracing_Bias_Real(
-                    inv_guess,
-                    trans_coords,
-                    esv_bias[j],
-                    dz_array,
-                    angle_array,
-                    esv_matrix,
-                )
+
+        if split_esv:
+            times_guess, esv = calculateTimesRayTracing_split(
+                inv_guess,
+                trans_coords,
+                esv_bias[j],
+                dz_array,
+                angle_array,
+                esv_matrix,
+            )
+        else:
+            times_guess, esv = calculateTimesRayTracing_Bias_Real(
+                inv_guess,
+                trans_coords,
+                esv_bias[j],
+                dz_array,
+                angle_array,
+                esv_matrix,
+            )
 
             """Note doing GPS_data - time_bias to
             include time_bias in offset when calculating travel times"""
-            (
-                CDOG_clock,
-                CDOG_full,
-                GPS_clock,
-                GPS_full,
-                transponder_coordinates_full,
-                esv_full,
-            ) = two_pointer_index(
-                offsets[j],
-                0.6,
-                CDOG_data,
-                GPS_data + time_bias[j],
-                times_guess,
-                trans_coords,
-                esv,
-                True,
-            )
-        except Exception as e:
-            # if inversion fails, give very low likelihood
-            print("Error: ", e)
-            return -np.inf
+        (
+            CDOG_clock,
+            CDOG_full,
+            GPS_clock,
+            GPS_full,
+            transponder_coordinates_full,
+            esv_full,
+        ) = two_pointer_index(
+            offsets[j],
+            0.6,
+            CDOG_data,
+            GPS_data + time_bias[j],
+            times_guess,
+            trans_coords,
+            esv,
+            True,
+        )
         resid = (CDOG_full - GPS_full) * 1515 * 100
         total_ssq += np.sqrt(np.nansum(resid**2) / len(resid))
     # assume Gaussian errors with unit variance:
@@ -156,6 +153,13 @@ def mcmc_sampler(
     if initial_esv_bias.ndim == 2:
         split_esv = True
         num_splits = initial_esv_bias.shape[1]
+
+    # ensure CDOG_all_data is a numba typed list
+    if not isinstance(CDOG_all_data, List):
+        typed_list = List()
+        for arr in CDOG_all_data:
+            typed_list.append(arr)
+        CDOG_all_data = typed_list
 
     # initialize chain
     lever_chain = np.zeros((n_iters, 3))


### PR DESCRIPTION
## Summary
- jit compile `compute_log_likelihood`
- jit compile `calculateTimesRayTracing_split`
- avoid python list usage in `mcmc_sampler`

## Testing
- `pip install -e .[test]`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68620c723f58832f97289d6243d22ba2