### PR TITLE
Add shared plot save helper and unify plotting outputs

### DIFF
--- a/src/plotting/KDE_MCMC.py
+++ b/src/plotting/KDE_MCMC.py
@@ -6,6 +6,7 @@ from scipy.stats import gaussian_kde
 from data import gps_output_path
 from plotting.Ellipses.Prior_Ellipse import plot_prior_ellipse
 from plotting.MCMC_plots import get_init_params_and_prior
+from .save import save_plot
 
 
 def plot_kde_mcmc(
@@ -17,6 +18,9 @@ def plot_kde_mcmc(
     confidences=(0.68, 0.95),
     CDOG_reference=None,
     ellipses=0,
+    save=False,
+    chain_name=None,
+    path="Figs",
 ):
     if CDOG_reference is None:
         CDOG_reference = np.array([1976671.618715, -5069622.53769779, 3306330.69611698])
@@ -127,6 +131,8 @@ def plot_kde_mcmc(
     ax2.set_ylim(-lim_pcz, lim_pcz)
 
     plt.tight_layout()
+    if save:
+        save_plot(fig, chain_name, "plot_kde_mcmc", subdir=path)
     plt.show()
 
 

--- a/src/plotting/MCMC_ratio.py
+++ b/src/plotting/MCMC_ratio.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import gaussian_kde, norm
+from .save import save_plot
 
 
 def plot_marginal_density_ratio(
@@ -11,6 +12,9 @@ def plot_marginal_density_ratio(
     pct_trim=(1, 99),
     min_prior_pdf=1e-8,
     show_densities=False,
+    save=False,
+    chain_name=None,
+    path="Figs",
 ):
     """
     Plot the ratio of posterior to prior marginal densities for a single parameter,
@@ -61,6 +65,8 @@ def plot_marginal_density_ratio(
         ax2.legend(loc="upper right")
 
     plt.tight_layout()
+    if save:
+        save_plot(fig, chain_name, "plot_marginal_density_ratio", subdir=path)
     plt.show()
 
     return grid, ratio

--- a/src/plotting/MCMC_threshold_posterior.py
+++ b/src/plotting/MCMC_threshold_posterior.py
@@ -4,7 +4,7 @@ from MCMC_plots import corner_plot, get_init_params_and_prior
 from data import gps_output_path
 
 
-def threshold_posterior(chain, threshold=-50, save=False, timestamp=None):
+def threshold_posterior(chain, threshold=-50, save=False, chain_name=None):
     initial_params, prior_scales = get_init_params_and_prior(chain)
 
     mask = chain["logpost"] > threshold
@@ -20,13 +20,14 @@ def threshold_posterior(chain, threshold=-50, save=False, timestamp=None):
         f" {len(reduced_chain['logpost'])} with threshold {threshold}"
     )
 
+    name = f"threshold_{threshold}_{chain_name}" if chain_name else f"threshold_{threshold}"
     corner_plot(
         reduced_chain,
         initial_params=initial_params,
         prior_scales=prior_scales,
         downsample=1,
         save=save,
-        timestamp=f"threshold_{threshold}_" + timestamp,
+        chain_name=name,
         loglike=loglike,
     )
     return
@@ -38,10 +39,7 @@ if __name__ == "__main__":
     loglike = True
     save = True
 
-    if loglike:
-        timestamp = file_name
-    else:
-        timestamp = file_name
+    chain_name = file_name
     chain = np.load(gps_output_path(file_name))
 
-    threshold_posterior(chain, threshold=-45, save=save, timestamp=timestamp)
+    threshold_posterior(chain, threshold=-45, save=save, chain_name=chain_name)

--- a/src/plotting/Misc/plot_plane.py
+++ b/src/plotting/Misc/plot_plane.py
@@ -2,9 +2,10 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
+from plotting.save import save_plot
 
 
-def plotPlane(point, normVect, xrange, yrange):
+def plotPlane(point, normVect, xrange, yrange, save=False, chain_name=None, path="Figs"):
     """Plot a plane defined by a point and its normal vector.
 
     Parameters
@@ -15,6 +16,12 @@ def plotPlane(point, normVect, xrange, yrange):
         Normal vector of the plane.
     xrange, yrange : sequence of float
         ``[min, max]`` bounds describing the extent of the mesh grid.
+    save : bool, optional
+        If True, save the figure to disk.
+    chain_name : str, optional
+        Identifier used in the saved filename.
+    path : str, optional
+        Subdirectory under the Data directory in which to save.
 
     Returns
     -------
@@ -39,6 +46,9 @@ def plotPlane(point, normVect, xrange, yrange):
     ax.set_xlabel("x")
     ax.set_ylabel("y")
     ax.set_zlabel("z")
+
+    if save:
+        save_plot(fig, chain_name, "plot_plane", subdir=path)
 
     return ax
 

--- a/src/plotting/Plot_Segments.py
+++ b/src/plotting/Plot_Segments.py
@@ -104,7 +104,7 @@ def plot_combined_segments(n_splits, path, DOG_num=0):
         block=True,
         save=True,
         path="Figs",
-        timestamp="7_individual_splits_esv_20250806_143356",
+        chain_name="7_individual_splits_esv_20250806_143356",
         segments=n_splits,
     )
 

--- a/src/plotting/save.py
+++ b/src/plotting/save.py
@@ -1,0 +1,20 @@
+import os
+from typing import Optional
+from data import gps_data_path
+
+def save_plot(fig, chain_name: Optional[str], func_name: str, subdir: str = "Figs", ext: str = "pdf"):
+    """Save ``fig`` to ``subdir`` inside the Data directory.
+
+    The file name is built from ``chain_name`` and ``func_name`` and the figure
+    is saved as a PDF by default.
+    """
+    if chain_name is None:
+        chain_name = "chain"
+    # Set a descriptive title if one isn't already present
+    if not fig._suptitle:
+        fig.suptitle(f"{chain_name}: {func_name}")
+    fname = f"{chain_name}_{func_name}.{ext}"
+    dirpath = gps_data_path(subdir)
+    os.makedirs(dirpath, exist_ok=True)
+    fullpath = dirpath / fname
+    fig.savefig(fullpath, format=ext, bbox_inches="tight")


### PR DESCRIPTION
## Summary
- add `save_plot` utility that builds PDF filenames from chain and function names
- refactor plotting modules to use `save_plot` instead of bespoke save logic
- enable optional saving in plotting functions that previously only displayed figures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b70d0f3e40832f82fece7a2352fb23