### PR TITLE
Refactor ESV lookup into shared helper

### DIFF
--- a/src/Inversion_Workflow/Forward_Model/Calculate_Times.py
+++ b/src/Inversion_Workflow/Forward_Model/Calculate_Times.py
@@ -3,45 +3,7 @@ from numba import njit
 
 from Inversion_Workflow.Inversion.Numba_Geiger import dz_array, angle_array, esv_matrix
 from geometry.ECEF_Geodetic import ECEF_Geodetic
-
-
-@njit
-def find_esv(beta, dz):
-    """Look up effective sound velocities for given angles and depths.
-
-    Parameters
-    ----------
-    beta : ndarray
-        Ray takeoff angles in degrees.
-    dz : ndarray
-        Vertical distance between the receiver and the source.
-
-    Returns
-    -------
-    ndarray
-        Effective sound velocity for each input pair.
-    """
-    idx_closest_dz = np.empty_like(dz, dtype=np.int64)
-    idx_closest_beta = np.empty_like(beta, dtype=np.int64)
-
-    for i in range(len(dz)):
-        idx_closest_dz[i] = np.searchsorted(dz_array, dz[i], side="left")
-        if idx_closest_dz[i] < 0:
-            idx_closest_dz[i] = 0
-        elif idx_closest_dz[i] >= len(dz_array):
-            idx_closest_dz[i] = len(dz_array) - 1
-
-        idx_closest_beta[i] = np.searchsorted(angle_array, beta[i], side="left")
-        if idx_closest_beta[i] < 0:
-            idx_closest_beta[i] = 0
-        elif idx_closest_beta[i] >= len(angle_array):
-            idx_closest_beta[i] = len(angle_array) - 1
-
-    closest_esv = np.empty_like(dz, dtype=np.float64)
-    for i in range(len(dz)):
-        closest_esv[i] = esv_matrix[idx_closest_dz[i], idx_closest_beta[i]]
-
-    return closest_esv
+from Inversion_Workflow.Forward_Model.Find_ESV import find_esv
 
 
 @njit
@@ -67,7 +29,7 @@ def calculateTimesRayTracingReal(guess, transponder_coordinates):
     lat, lon, depth = ECEF_Geodetic(guess)
     dz = depth_arr - depth
     beta = np.arcsin(dz / abs_dist) * 180 / np.pi
-    esv = find_esv(beta, dz)
+    esv = find_esv(beta, dz, dz_array, angle_array, esv_matrix)
     times = abs_dist / esv
     return times, esv
 
@@ -97,7 +59,7 @@ def calculateTimesRayTracing(guess, transponder_coordinates, ray=True):
     abs_dist = np.sqrt(np.sum((transponder_coordinates - guess) ** 2, axis=1))
     beta = np.arccos(hori_dist / abs_dist) * 180 / np.pi
     dz = np.abs(guess[2] - transponder_coordinates[:, 2])
-    esv = find_esv(beta, dz)
+    esv = find_esv(beta, dz, dz_array, angle_array, esv_matrix)
     times = abs_dist / esv
     if not ray:
         times = abs_dist / 1515.0

--- a/src/Inversion_Workflow/Forward_Model/Calculate_Times_Bias.py
+++ b/src/Inversion_Workflow/Forward_Model/Calculate_Times_Bias.py
@@ -2,47 +2,7 @@ import numpy as np
 from numba import njit
 
 from geometry.ECEF_Geodetic import ECEF_Geodetic
-
-
-@njit
-def find_esv(beta, dz, dz_array, angle_array, esv_matrix):
-    """Interpolate effective sound velocities from a lookup table.
-
-    Parameters
-    ----------
-    beta : ndarray
-        Takeoff angles in degrees.
-    dz : ndarray
-        Vertical separation of receiver and source.
-    dz_array, angle_array, esv_matrix : ndarray
-        Discrete lookup grids defining the ESV table.
-
-    Returns
-    -------
-    ndarray
-        Interpolated effective sound velocities.
-    """
-    idx_closest_dz = np.empty_like(dz, dtype=np.int64)
-    idx_closest_beta = np.empty_like(beta, dtype=np.int64)
-
-    for i in range(len(dz)):
-        idx_closest_dz[i] = np.searchsorted(dz_array, dz[i], side="left")
-        if idx_closest_dz[i] < 0:
-            idx_closest_dz[i] = 0
-        elif idx_closest_dz[i] >= len(dz_array):
-            idx_closest_dz[i] = len(dz_array) - 1
-
-        idx_closest_beta[i] = np.searchsorted(angle_array, beta[i], side="left")
-        if idx_closest_beta[i] < 0:
-            idx_closest_beta[i] = 0
-        elif idx_closest_beta[i] >= len(angle_array):
-            idx_closest_beta[i] = len(angle_array) - 1
-
-    closest_esv = np.empty_like(dz, dtype=np.float64)
-    for i in range(len(dz)):
-        closest_esv[i] = esv_matrix[idx_closest_dz[i], idx_closest_beta[i]]
-
-    return closest_esv
+from Inversion_Workflow.Forward_Model.Find_ESV import find_esv
 
 
 @njit

--- a/src/Inversion_Workflow/Forward_Model/Find_ESV.py
+++ b/src/Inversion_Workflow/Forward_Model/Find_ESV.py
@@ -1,0 +1,43 @@
+import numpy as np
+from numba import njit
+
+
+@njit
+def find_esv(beta, dz, dz_array, angle_array, esv_matrix):
+    """Look up effective sound velocities for given angles and depths.
+
+    Parameters
+    ----------
+    beta : ndarray
+        Ray takeoff angles in degrees.
+    dz : ndarray
+        Vertical distance between the receiver and the source.
+    dz_array, angle_array, esv_matrix : ndarray
+        Discrete lookup grids defining the ESV table.
+
+    Returns
+    -------
+    ndarray
+        Effective sound velocity for each input pair.
+    """
+    idx_closest_dz = np.empty_like(dz, dtype=np.int64)
+    idx_closest_beta = np.empty_like(beta, dtype=np.int64)
+
+    for i in range(len(dz)):
+        idx_closest_dz[i] = np.searchsorted(dz_array, dz[i], side="left")
+        if idx_closest_dz[i] < 0:
+            idx_closest_dz[i] = 0
+        elif idx_closest_dz[i] >= len(dz_array):
+            idx_closest_dz[i] = len(dz_array) - 1
+
+        idx_closest_beta[i] = np.searchsorted(angle_array, beta[i], side="left")
+        if idx_closest_beta[i] < 0:
+            idx_closest_beta[i] = 0
+        elif idx_closest_beta[i] >= len(angle_array):
+            idx_closest_beta[i] = len(angle_array) - 1
+
+    closest_esv = np.empty_like(dz, dtype=np.float64)
+    for i in range(len(dz)):
+        closest_esv[i] = esv_matrix[idx_closest_dz[i], idx_closest_beta[i]]
+
+    return closest_esv

--- a/src/Inversion_Workflow/Inversion/Numba_Geiger.py
+++ b/src/Inversion_Workflow/Inversion/Numba_Geiger.py
@@ -3,7 +3,6 @@ import numpy as np
 import scipy.io as sio
 from numba import njit
 
-from Inversion_Workflow.Forward_Model.Calculate_Times import calculateTimesRayTracing
 from Inversion_Workflow.Forward_Model.Find_Transponder import findTransponder
 from data import gps_data_path
 import timeit
@@ -63,6 +62,10 @@ def geigersMethod(
     tuple of ndarray
         ``(estimate, times_known)`` final position and noisy arrival times.
     """
+    from Inversion_Workflow.Forward_Model.Calculate_Times import (
+        calculateTimesRayTracing,
+    )
+
     # Define threshold
     epsilon = 10**-5
     times_known, esv = calculateTimesRayTracing(CDog, transponder_coordinates_Actual)


### PR DESCRIPTION
## Summary
- centralize ESV table lookup in new `find_esv` helper with explicit grid inputs
- update `Calculate_Times` and `Calculate_Times_Bias` to call the shared helper
- move `calculateTimesRayTracing` import inside `Numba_Geiger.geigersMethod` to avoid circular imports

## Testing
- `pre-commit run --files src/Inversion_Workflow/Forward_Model/Find_ESV.py src/Inversion_Workflow/Forward_Model/Calculate_Times.py src/Inversion_Workflow/Forward_Model/Calculate_Times_Bias.py src/Inversion_Workflow/Inversion/Numba_Geiger.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b84c0994b8832fbf124cfccc4f534c