### PR TITLE
Ensure ray-tracing calls include ESV parameters

### DIFF
--- a/src/Inversion_Workflow/Bermuda/Bermuda_Data.py
+++ b/src/Inversion_Workflow/Bermuda/Bermuda_Data.py
@@ -16,6 +16,9 @@ import matplotlib.pyplot as plt
 from data import gps_data_path
 
 esv_table = sio.loadmat(gps_data_path("ESV_Tables/global_table_esv.mat"))
+dz_array = esv_table["distance"].flatten()
+angle_array = esv_table["angle"].flatten()
+esv_matrix = esv_table["matrice"]
 
 """
 Process:
@@ -46,7 +49,14 @@ transponder_coordinates = findTransponder(
     GPS_Coordinates, gps1_to_others, initial_lever_guess
 )
 inversion_guess, best_offset = initial_geiger(
-    CDOG_guess, CDOG_data, GPS_data, transponder_coordinates, real_data=True
+    CDOG_guess,
+    CDOG_data,
+    GPS_data,
+    transponder_coordinates,
+    dz_array,
+    angle_array,
+    esv_matrix,
+    real_data=True,
 )
 print("Initial Complete:", best_offset)
 inversion_guess, best_offset = transition_geiger(
@@ -55,6 +65,9 @@ inversion_guess, best_offset = transition_geiger(
     GPS_data,
     transponder_coordinates,
     best_offset,
+    dz_array,
+    angle_array,
+    esv_matrix,
     real_data=True,
 )
 print("Transition Complete:", best_offset)
@@ -67,6 +80,9 @@ inversion_guess, CDOG_full, GPS_full, CDOG_clock, GPS_clock = final_geiger(
     GPS_data,
     transponder_coordinates,
     best_offset,
+    dz_array,
+    angle_array,
+    esv_matrix,
     real_data=True,
 )
 print("Final Complete")

--- a/src/Inversion_Workflow/Inversion/Numba_Geiger.py
+++ b/src/Inversion_Workflow/Inversion/Numba_Geiger.py
@@ -41,6 +41,9 @@ def geigersMethod(
     CDog,
     transponder_coordinates_Actual,
     transponder_coordinates_Found,
+    dz_array,
+    angle_array,
+    esv_matrix,
     time_noise=0,
 ):
     """Iteratively refine a CDOG position using Geiger's algorithm.
@@ -66,7 +69,9 @@ def geigersMethod(
 
     # Define threshold
     epsilon = 10**-5
-    times_known, esv = calculateTimesRayTracing(CDog, transponder_coordinates_Actual)
+    times_known, esv = calculateTimesRayTracing(
+        CDog, transponder_coordinates_Actual, dz_array, angle_array, esv_matrix
+    )
 
     # Apply noise to known times
     times_known += np.random.normal(0, time_noise, len(transponder_coordinates_Actual))
@@ -76,7 +81,7 @@ def geigersMethod(
     # Loop until change in guess is less than the threshold
     while np.linalg.norm(delta) > epsilon and k < 100:
         times_guess, esv = calculateTimesRayTracing(
-            guess, transponder_coordinates_Found
+            guess, transponder_coordinates_Found, dz_array, angle_array, esv_matrix
         )
         jacobian = computeJacobianRayTracing(
             guess, transponder_coordinates_Found, times_guess, esv
@@ -133,6 +138,9 @@ if __name__ == "__main__":
             CDog,
             transponder_coordinates_Actual,
             transponder_coordinates_Found,
+            dz_array,
+            angle_array,
+            esv_matrix,
             time_noise,
         )
     stop = timeit.default_timer()


### PR DESCRIPTION
## Summary
- Pass dz_array, angle_array, and esv_matrix through geiger and annealing routines so calculateTimesRayTracing functions receive required parameters
- Update Bermuda data example to supply ESV lookup tables to geiger helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86ffdce28832fa656617b0b279569